### PR TITLE
Add more notes for multi-module projects

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -40,7 +40,7 @@ JitPack will run:
 
     mvn install -DskipTests
     
-to build and publish Maven projects. 
+to build and publish Maven projects. Your Maven group id is harvested from the top-level pom and then used to locate the installed artifacts in `~/.m2/repository`. Binary jars, source jars and javadoc can all be picked up from there via the JitPack virtual repository.
 
 ### Example projects
 
@@ -76,6 +76,33 @@ compile 'com.github.User:Repo:Tag'
 Examples:
  - Multiple Gradle modules - https://github.com/jitpack/gradle-modular
  - Multiple Maven modules - https://github.com/jitpack/maven-modular
+ 
+ N.B. in a Maven multi-module build, the top level is always a pom (not a jar), but it *can* still be used to aggregate javadocs, as long as they are published as a jar file when the project is built. You can configure the javadoc plugin at the top level like this, and the javadocs will be published with an artifact id the same as the top level pom:
+ 
+ ```xml
+<build>
+    <pluginManagement>
+        <plugins>
+            <plugin>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <inherited>false</inherited>
+                <configuration>
+                    <aggregate>true</aggregate>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>aggregate</id>
+                        <goals>
+                            <goal>aggregate-jar</goal>
+                        </goals>
+                        <phase>package</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </pluginManagement>
+</build>
+```
 
 ## Sbt projects
 

--- a/README.md
+++ b/README.md
@@ -105,8 +105,15 @@ It's easy to look up the dependency information on https://jitpack.io. Just past
 
 Other Features
 ======
-- Javadoc publishing. If the project produces a javadoc.jar then you can browse the javadoc files directly at: 
-    - `https://jitpack.io/com/github/USER/REPO/VERSION/javadoc/`   
+- Javadoc publishing. For a single module project, if it produces a javadoc.jar then you can browse the javadoc files directly at: 
+    - `https://jitpack.io/com/github/USER/REPO/VERSION/javadoc/` 
+
+- For a multi module project, the artifacts are published under `com.github.USER.REPO:MODULE:VERSION`, where `MODULE` is the artifact id of the module (not necessarily the same as the directory it lives in)
+- Javadocs for a multi-module project follow the same convention, i.e.
+
+    - `https://jitpack.io/com/github/USER/REPO/MODULE/VERSION/javadoc/` 
+
+- Aggregated javadocs for a multi-module project may be available if the top level aggregates them into a jar and publishes it. The module name in this case is the artifact id of the top level module.
 - Private repositories https://jitpack.io/private
 - Dynamic versions. You can youse Gradle's dynamic version '1.+' and Maven's version ranges for releases. They resolve to releases that have already been built.
 - Build by tag and by commit id.


### PR DESCRIPTION
Javadocs, in particular, are hard to discover if you don't know
the conventions. This change makes it more explicit for users
and publishers of jars.

I don't know how to do the javadoc aggregation with other build
tools, so I only gave an example for Maven.